### PR TITLE
Using only the default auto commit interval 

### DIFF
--- a/mongo_connector/doc_managers/neo4j_doc_manager.py
+++ b/mongo_connector/doc_managers/neo4j_doc_manager.py
@@ -39,8 +39,6 @@ class DocManager(DocManagerBase):
     self.auto_commit_interval = auto_commit_interval
     self.unique_key = unique_key
     self.chunk_size = chunk_size
-    if self.auto_commit_interval not in [None, 0]:
-      self.run_auto_commit()
     self._formatter = DefaultDocumentFormatter()
 
   def apply_id_constraint(self, doc_types):


### PR DESCRIPTION
@johnymontana 

"auto_commit_interval is the time period, in seconds, between when the DocManager should attempt to commit any outstanding changes to the indexing system. A value of None indicates that mongo-connector should not attempt to sync any changes automatically."

We can pass a default value of none at the constructor.